### PR TITLE
Package Name & Version Bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools >= 77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "cffdrs-py"
-version = "0.1.2"
+name = "cffdrs"
+version = "0.2.0"
 authors = [{ name = "Jordan Evens", email = "jordan.evens@nrcan-rncan.gc.ca" }]
 description = "A Python package for CFFDRS"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -10,8 +10,8 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "cffdrs-py"
-version = "0.1.2"
+name = "cffdrs"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
When I regenerated the `pyproject.toml` with `uv`, I didn't notice the package name changed from `cffdrs` to `cffdrs-py`, this PR changes that back and bumps the minor version to `0.2.0`