### PR TITLE
Fix: Unify initial_spread_index and _initial_spread_index back into one function

### DIFF
--- a/cffdrs/fire_behaviour_prediction.py
+++ b/cffdrs/fire_behaviour_prediction.py
@@ -1,7 +1,7 @@
 import math
 from typing import Literal, NamedTuple
 from cffdrs.constants import D1, S1, S2, S3, O1A, O1B, C6, NF, WA, FUEL_TYPE_CODES
-from cffdrs.fwi import _initial_spread_index
+from cffdrs.fwi import initial_spread_index
 from cffdrs.rate_of_spread import _rate_of_spread_extended
 from cffdrs.slope_calc import _slope_adjustment
 from cffdrs.surface_fuel_consumption import _surface_fuel_consumption
@@ -326,7 +326,7 @@ def _fire_behaviour_prediction(
     raz0 = slope_values.raz
     raz = raz0 if gs > 0 and ffmc > 0 else waz
     # Calculate or keep Initial Spread Index (ISI)
-    isi = isi if isi > 0 else _initial_spread_index(ffmc, wsv, True)
+    isi = isi if isi > 0 else initial_spread_index(ffmc, wsv, True)
     # HACK: C6 ROS depends on CFB so do this to not repeat calculations
     ros_vars = _rate_of_spread_extended(fuel_type_code, isi, bui_eff, fmc, sfc, pc, pdf, cc, cbh)
     ros = ros_vars.ros

--- a/cffdrs/fwi.py
+++ b/cffdrs/fwi.py
@@ -313,45 +313,6 @@ def drought_code(dc_yda, temp, rh, prec, lat, mon, lat_adjust=True):
     return dc1
 
 
-def _initial_spread_index(ffmc: float, ws: float, fbp_mod: bool = False) -> float:
-    """
-    Vectorization-ready Initial Spread Index Calculation.
-
-    Same formula as initial_spread_index(), but without the range-validating
-    `raise ValueError` guards - dynamic exception messages aren't
-    traceable/compilable by array-vectorization tools like numba or jax, and
-    within the FBP system, inputs are already range-clamped once up front (see
-    FBPInput.__post_init__) before reaching this calculation. A caller
-    vectorizing over arrays of inputs is expected to validate/clamp the same
-    way, once, over the whole array.
-
-    Parameters
-    ----------
-    ffmc : float
-       Fine Fuel Moisture Code
-    ws : float
-       Wind Speed (km/h)
-    fbp_mod : bool, default=False
-       Use the fbp modification at the extreme end
-
-    Returns
-    -------
-    float
-        Initial Spread Index
-    """
-    # Eq. 10 - Moisture content
-    fm = FFMC_COEFFICIENT * (101 - ffmc) / (59.5 + ffmc)
-    # Eq. 24 - Wind Effect
-    # the ifelse, also takes care of the ISI modification for the fbp functions
-    # This modification is Equation 53a in FCFDG (1992)
-    fW = (12 * (1 - exp(-0.0818 * (ws - 28)))) if (ws >= 40 and fbp_mod) else exp(0.05039 * ws)
-    # Eq. 25 - Fine Fuel Moisture
-    fF = 91.9 * exp(-0.1386 * fm) * (1 + (fm**5.31) / 49300000)
-    # Eq. 26 - Spread Index Equation
-    isi = 0.208 * fW * fF
-    return isi
-
-
 def initial_spread_index(ffmc, ws, fbp_mod=False):
     """
     Initial Spread Index Calculation
@@ -389,7 +350,17 @@ def initial_spread_index(ffmc, ws, fbp_mod=False):
         raise ValueError(f"Invalid ffmc: {ffmc}")
     if ws < 0:
         raise ValueError(f"Invalid ws: {ws}")
-    return _initial_spread_index(ffmc, ws, fbp_mod)
+    # Eq. 10 - Moisture content
+    fm = FFMC_COEFFICIENT * (101 - ffmc) / (59.5 + ffmc)
+    # Eq. 24 - Wind Effect
+    # the ifelse, also takes care of the ISI modification for the fbp functions
+    # This modification is Equation 53a in FCFDG (1992)
+    fW = (12 * (1 - exp(-0.0818 * (ws - 28)))) if (ws >= 40 and fbp_mod) else exp(0.05039 * ws)
+    # Eq. 25 - Fine Fuel Moisture
+    fF = 91.9 * exp(-0.1386 * fm) * (1 + (fm**5.31) / 49300000)
+    # Eq. 26 - Spread Index Equation
+    isi = 0.208 * fW * fF
+    return isi
 
 
 def buildup_index(dmc, dc):

--- a/cffdrs/slope_calc.py
+++ b/cffdrs/slope_calc.py
@@ -29,7 +29,7 @@ from cffdrs.constants import (
     NF,
     WA,
 )
-from cffdrs.fwi import _initial_spread_index
+from cffdrs.fwi import initial_spread_index
 from cffdrs.r_helpers import safe_div
 from cffdrs.rate_of_spread import _rate_of_spread
 
@@ -84,7 +84,7 @@ def _slope_adjustment(
     # Eq. 39 (FCFDG 1992) - Calculate Spread Factor
     sf = 10 if gs >= 70 else math.exp(3.533 * (gs / 100) ** 1.2)
     # ISI with 0 wind on level grounds
-    isz = _initial_spread_index(ffmc, 0)
+    isz = initial_spread_index(ffmc, 0)
     # Surface spread rate with 0 wind on level ground
     rsz = _rate_of_spread(fuel_type_code, isz, no_bui, fmc, sfc, pc, pdf, cc, cbh)
     # Eq. 40 (FCFDG 1992) - Surface spread rate with 0 wind upslope

--- a/cffdrs/tests/test_fwi.py
+++ b/cffdrs/tests/test_fwi.py
@@ -4,7 +4,6 @@ from cffdrs.fwi import (
     duff_moisture_code,
     drought_code,
     initial_spread_index,
-    _initial_spread_index,
     buildup_index,
     fire_weather_index,
 )
@@ -111,27 +110,6 @@ def test_isi(fwi_test_data):
         # Use a small tolerance for floating point comparison
         assert pytest.approx(result, abs=0.1) == expected_isi, (
             f"Failed for row: {row}, got {result}, expected {expected_isi}"
-        )
-
-        current_ffmc = result_ffmc
-
-
-def test_isi_equivalence(fwi_test_data):
-    """_initial_spread_index must match initial_spread_index."""
-    current_ffmc = 85.0
-
-    for row in fwi_test_data:
-        temp = row["TEMP"]
-        rh = row["RH"]
-        ws = row["WS"]
-        prec = row["PREC"]
-
-        result_ffmc = fine_fuel_moisture_code(current_ffmc, temp, rh, ws, prec)
-        expected = initial_spread_index(result_ffmc, ws)
-        calculated = _initial_spread_index(result_ffmc, ws)
-
-        assert pytest.approx(expected, abs=1e-9, nan_ok=True) == calculated, (
-            f"Failed for row: {row}, core={calculated}, scalar={expected}"
         )
 
         current_ffmc = result_ffmc


### PR DESCRIPTION
The split between `initial_spread_index` (guarded, public) and `_initial_spread_index` (guard-free, private) broke `initial_spread_index`'s own direct vectorizability since numba can't compile a call from one function into a second, uncompiled function, so `vectorize(initial_spread_index)` fails even though the guard itself compiles fine. The split also had an indirect side effect where the _fire_behaviour_prediction is the guard-free version internally calls `_initial_spread_index(ffmc, wsv, True)` without any guard checks.

The split was introduced as part of a blanket pass ("vectorize internals") that gave every function in the FBP composition graph a public/private split uniformly, regardless of whether each one individually needed it. Most did require it because fuel-type string dispatch or recursion existed which vectorization tools can't trace. `initial_spread_index` didn't: it doesn't branch on fuel type, and testing confirms numba compiles its `raise ValueError` guards fine, both standalone and when called from inside another jitted function (`_slope_adjustment`, `_fire_behaviour_prediction`). 

This merges `initial_spread_index` and `_initial_spread_index` function in `fwi.py`, and updated the two internal call sites in `slope_calc.py` and `fire_behaviour_prediction.py` to call it directly restoring both direct vectorizability and the lost validation.